### PR TITLE
Fix: Resolve 'container is not defined' error in runMiner function

### DIFF
--- a/main.js
+++ b/main.js
@@ -501,10 +501,6 @@ function runMiner(creep) {
                    structure.pos.getRangeTo(source) <= 2;
         }
     })[0];
-}
-
-function countMissingStructures(room) {
-    if (!room.memory.plannedStructures) return 0;
     
     if (container) {
         // Move to container position and stay there


### PR DESCRIPTION
- Fixed duplicate countMissingStructures function definition inside runMiner
- Moved container logic back into proper scope within runMiner function
- Resolves ReferenceError that was breaking creep spawning logic